### PR TITLE
Fix docs image width overflow

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -677,15 +677,15 @@ export default {
 }
 
 .horisontal-large-image {
-  width: 100vw;
+  width: 100%;
   height: 37vw;
   margin-top: 2em;
   overflow: hidden;
   img {
     position: relative;
     top: -5vw;
-    left: -50vw;
-    width: 200vw;
+    left: -50%;
+    width: 200%;
   }
 }
 


### PR DESCRIPTION
image would be overflow while scroll bar show because of `100vw`

Mac:
<img width="886" alt="Victor_Mono" src="https://user-images.githubusercontent.com/29639463/60029065-01902300-96d3-11e9-861d-836a2d8c01af.png">

Windows:
![2019-06-24 12_39_09-Clipboard](https://user-images.githubusercontent.com/29639463/60029125-208eb500-96d3-11e9-9859-733046dca601.png)

Fixed:
<img width="961" alt="Victor_Mono_and_General_and_DevTools_-_localhost_8080__and_App_vue_—_victor-mono_and_Downloads_and_rubjo" src="https://user-images.githubusercontent.com/29639463/60029238-55027100-96d3-11e9-975a-95b20c767e3b.png">

