### PR TITLE
Reflect deprecation in brew 2.6.0 install command

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -341,7 +341,7 @@
             </em>
             <br>
             <code>brew tap homebrew/cask-fonts</code><br>
-            <code>brew cask install font-victor-mono</code>
+            <code>brew install --cask font-victor-mono</code>
           </p>
         </el-col>
         <el-col


### PR DESCRIPTION
This change updates the brew install command to reflect breaking brew API changes.

The brew project deprecated `brew cask install` in favor of `brew install --cask` in [2.6.0](https://brew.sh/2020/12/01/homebrew-2.6.0/) on 2020/12/01 and the `brew cask` commands were fully removed in [2.7.0](https://brew.sh/2020/12/21/homebrew-2.7.0/)  on 2020/12/21.

Though the speed of the deprecation has been [controversial](https://github.com/Homebrew/discussions/discussions/340) the change has landed. The only thing holding back a merge in my opinion is some unknown measure of how fast people will update to at least 2.6.0, containing the new `--cask` flag.