### PR TITLE
Change the font selector's background when switching to dark theme

### DIFF
--- a/src/components/Compare.vue
+++ b/src/components/Compare.vue
@@ -175,6 +175,10 @@ export default {
         transform: scale(1.1);
       }
 
+      option {
+        background: var(--background-color-base);
+      }
+
       // Disable default styling on ff
       -moz-appearance: none;
 


### PR DESCRIPTION
This PR aims to fix the hard to read select options when someone uses the site's dark theme.

Before:

![image](https://user-images.githubusercontent.com/31937175/134227981-be26157f-4d02-44f2-9ced-b595c061492a.png)

After:

![image](https://user-images.githubusercontent.com/31937175/134228025-68aba4c2-0123-47a4-a138-185f7b3e0fb1.png)

I've tested this on chrome and firefox.