### PR TITLE
Link the license from the FAQ

### DIFF
--- a/src/components/Faq.vue
+++ b/src/components/Faq.vue
@@ -66,7 +66,7 @@ export default {
           category: 'Design & features'
         }, {
           title: 'Can I use the font for anything?',
-          value: 'Yes. If you\'d like to say thanks, you can <a href="https://paypal.me/runbjo" class="donate" target="_blank">donate</a>. I\'d also appreciate it if you referred others to this web site rather than serving the font files from elsewhere.',
+          value: 'Yes. The font is <a href="https://github.com/rubjo/victor-mono/blob/master/LICENSE">released under the SIL Open Font License</a>. If you\'d like to say thanks, you can <a href="https://paypal.me/runbjo" class="donate" target="_blank">donate</a>. I\'d also appreciate it if you referred others to this web site rather than serving the font files from elsewhere.',
           category: 'Usage'
         }, {
           title: 'I found a bug. Where do I report it?',


### PR DESCRIPTION
I found it strange that the website proudly declares "open source", and I came to it via HackerNews where it's described as a "Free font", and yet there's no mention of the license.

Here's a minimal improvement to link the license in the FAQ.

You might decide to link the license somewhere more prominently than this. Also you might add more text in the FAQ to describe the way the Open Font License doesn't impose any legal requirements on _using_ the font, only on redistributing the font itself (Seems like a good choice by the way. For a free font it makes more sense than the MIT license you had earlier https://github.com/rubjo/victor-mono/issues/120 )