### PR TITLE
Remove outdated link to `homebrew-cask-fonts`

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -326,13 +326,12 @@
             <em>With
               <a
                 target="_blank"
-                href="https://github.com/Homebrew/homebrew-cask-fonts"
+                href="https://brew.sh/"
               >
-                homebrew-cask-fonts</a>,
+                Homebrew</a>,
               just run
             </em>
             <br>
-            <code>brew tap homebrew/cask-fonts</code><br>
             <code>brew install --cask font-victor-mono</code>
           </p>
         </el-col>


### PR DESCRIPTION
No need to tap[ `homebrew-cask-fonts`](https://github.com/Homebrew/homebrew-cask-fonts) anymore!

- https://github.com/Homebrew/homebrew-cask-fonts

All of its contents got moved to the default `homebrew/cask` so it works without that step now 😊

![image](https://github.com/user-attachments/assets/536bcc91-e4f3-411a-b0cc-064dc1b28a9d)
